### PR TITLE
Adicionando Americanas da B2W

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Esse repo foi **inspirado** em [Empresas que usam React no Brasil](https://githu
 
 Nome | Site | Cidade | Tecnologias Relacionadas | Score  
 :------------: | ------------- | ------------------------ | ------------ | ---------------
+B2W | https://www.americanas.com.br/ | São Paulo | React, Redux, ReduxForm, Router | 0.33
 Beleza na Web | https://www.belezanaweb.com.br/ | São Paulo | React, React Native, Redux, Styled Components, AngularJS, NodeJS | 1.00 
 BrazilJS | https://braziljs.org/ | Porto Alegre | PHP, Wordpress, Web Components, JavaScript, Node.JS | 0.48 
 Buscapé | https://www.buscape.com.br/ | São Paulo | React, Redux, Redux-Thunk, Router | 0.48 


### PR DESCRIPTION
Bizarramente por não ter dois tamanhos de icones o PWA das americanas não passa na regra de **installable-manifest**, de qualquer forma instalou tranquilamente no meu Chrome Android.

<img width="925" alt="americanasPWA" src="https://user-images.githubusercontent.com/74883/63262143-92aaf280-c25b-11e9-8f87-fbf2ec0b41e2.PNG">
<img width="812" alt="americanasPWA2" src="https://user-images.githubusercontent.com/74883/63262144-92aaf280-c25b-11e9-8b35-636daf6594e9.PNG">
