### PR TITLE
Adicionando Posthaus

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Ifood | https://www.ifood.com.br | São Paulo | React, Redux | 0.74
 Melissa | https://www.melissa.com.br | Farroupilha | Javascript, jQuery | 1.00  
 Minimelissa | https://www.minimelissa.com.br | Farroupilha | Javascript, jQuery | 0.96  
 Mor | https://www.mor.com.br | Santa Cruz do Sul | Javascript, jQuery | 1.00  
+Posthaus | https://m.posthaus.com.br | Blumenau | React (SSR) | 0.74
 Reebok |  https://www.reebok.com.br | São Paulo | React, redux | 0.48
 Terra | https://www.terra.com.br | São Paulo | jQuery | 0.74
 


### PR DESCRIPTION
https://m.posthaus.com.br, score: 0.74
is-on-https:1, weight(2), 2
redirects-http:1, weight(2), 2
service-worker:1, weight(1), 1
works-offline:1, weight(5), 5
viewport:1, weight(2), 2
without-javascript:1, weight(1), 1
load-fast-enough-for-pwa:0, weight(7), 0
installable-manifest:1, weight(2), 2
apple-touch-icon:1, weight(1), 1
splash-screen:1, weight(1), 1
themed-omnibox:1, weight(1), 1
content-width:1, weight(1), 1
offline-start-url:1, weight(1), 1
pwa-cross-browser:null, weight(0), 0
pwa-page-transitions:null, weight(0), 0
pwa-each-page-has-url:null, weight(0), 0