### PR TITLE
Adicionando Cubo Network

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ BrazilJS | https://braziljs.org/ | Porto Alegre | PHP, Wordpress, Web Components
 Buscapé | https://www.buscape.com.br/ | São Paulo | React, Redux, Redux-Thunk, Router | 0.48 
 CEJS  | https://www.cejs.com.br/ | Fortaleza, CE | React, Material-ui, CRA | 1.00
 Coza  | https://www.coza.com.br/ | Caxias do Sul, RS | Javascript, jQuery | 0.74
+Cubo Network | https://cubo.network/ | São Paulo, SP | Angular | 0.96
 Dafiti | https://pwa.dafiti.com.br | São Paulo | Ionic, angularJS | 0.94
 Gympass | https://www.gympass.com/ | São Paulo | | 0.52
 Ifood | https://www.ifood.com.br | São Paulo | React, Redux | 0.74  


### PR DESCRIPTION
Adicionando PWD da Cubo Network

$ node index.js https://cubo.network/

https://cubo.network/, score: 0.96
is-on-https:1, weight(2), 2
redirects-http:1, weight(2), 2
service-worker:1, weight(1), 1
works-offline:1, weight(5), 5
viewport:1, weight(2), 2
without-javascript:1, weight(1), 1
load-fast-enough-for-pwa:1, weight(7), 7
installable-manifest:1, weight(2), 2
apple-touch-icon:0, weight(1), 0
splash-screen:1, weight(1), 1
themed-omnibox:1, weight(1), 1
content-width:1, weight(1), 1
offline-start-url:1, weight(1), 1
pwa-cross-browser:null, weight(0), 0
pwa-page-transitions:null, weight(0), 0
pwa-each-page-has-url:null, weight(0), 0