### PR TITLE
Adicionando Lojas Renner

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Coza  | https://www.coza.com.br/ | Caxias do Sul, RS | Javascript, jQuery | 0.74
 Dafiti | https://pwa.dafiti.com.br | São Paulo | Ionic, angularJS | 0.94
 Gympass | https://www.gympass.com/ | São Paulo | | 0.52
 Ifood | https://www.ifood.com.br | São Paulo | React, Redux | 0.74  
+Lojas Renner | https://www.lojasrenner.com.br | Porto Alegre | Vue, jQuery | 0.52
 Melissa | https://www.melissa.com.br | Farroupilha | Javascript, jQuery | 1.00  
 Minimelissa | https://www.minimelissa.com.br | Farroupilha | Javascript, jQuery | 0.96  
 Mor | https://www.mor.com.br | Santa Cruz do Sul | Javascript, jQuery | 1.00  


### PR DESCRIPTION
node index https://www.lojasrenner.com.br/

https://www.lojasrenner.com.br/, score: 0.52
is-on-https:1, weight(2), 2
redirects-http:1, weight(2), 2
service-worker:1, weight(1), 1
works-offline:0, weight(5), 0
viewport:1, weight(2), 2
without-javascript:1, weight(1), 1
load-fast-enough-for-pwa:0, weight(7), 0
installable-manifest:1, weight(2), 2
apple-touch-icon:1, weight(1), 1
splash-screen:1, weight(1), 1
themed-omnibox:1, weight(1), 1
content-width:1, weight(1), 1
offline-start-url:0, weight(1), 0
pwa-cross-browser:null, weight(0), 0
pwa-page-transitions:null, weight(0), 0
pwa-each-page-has-url:null, weight(0), 0